### PR TITLE
fix: remove owner tracking

### DIFF
--- a/contracts/StakingPool.sol
+++ b/contracts/StakingPool.sol
@@ -9,7 +9,6 @@ contract StakingPool {
 	using ABDKMath64x64 for int128;
 	using RolesLibrary for address;
 
-	address public owner;
 	address public claimManager;
 
 	uint256 public start;
@@ -38,10 +37,6 @@ contract StakingPool {
 	event StakeAdded(address indexed sender, uint256 amount, uint256 time);
 	event StakeWithdrawn(address indexed sender, uint256 amount);
 	event StakingPoolInitialized(uint256 funded, uint256 timestamp);
-	event OwnershipTransferred(
-		address indexed previousOwner,
-		address indexed newOwner
-	);
 
 	mapping(address => Stake) public stakes;
 
@@ -77,7 +72,6 @@ contract StakingPool {
 	}
 
 	constructor(bytes32 _ownerRole, address _claimManager) {
-		owner = msg.sender;
 		ownerRole = _ownerRole;
 		claimManager = _claimManager;
 	}
@@ -117,13 +111,6 @@ contract StakingPool {
 		remainingRewards = msg.value;
 
 		emit StakingPoolInitialized(msg.value, block.timestamp);
-	}
-
-	function changeOwner(address _newOwner) external onlyOwner {
-		require(owner != _newOwner, "changeOwner: already owner");
-		address oldOwner = owner;
-		owner = _newOwner;
-		emit OwnershipTransferred(oldOwner, _newOwner);
 	}
 
 	function stake()

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -33,14 +33,5 @@ module.exports = {
   typechain: {
     outDir: "ethers",
     target: "ethers-v5",
-    alwaysGenerateOverloads: false, // should overloads with full signatures like deposit(uint256) be generated always, even if there are no overloads?
-    externalArtifacts: [
-      "artifacts/contracts/kyc-token.sol/KycToken.json",
-      "artifacts/@openzeppelin/contracts/token/ERC20/IERC20.sol/IERC20.json",
-      "artifacts/@openzeppelin/contracts/token/ERC20/ERC20.sol/ERC20.json",
-      "artifacts/@openzeppelin/contracts/access/Ownable.sol/Ownable.json",
-      "artifacts/@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol/IERC20Metadata.json",
-      "artifacts/@openzeppelin/contracts/utils/Context.sol/Context.json",
-    ], // optional array of glob patterns with external artifacts to process (for example external libs from node_modules)
   },
 };

--- a/test/StakingPool.test.ts
+++ b/test/StakingPool.test.ts
@@ -137,20 +137,24 @@ describe("Staking Pool", function () {
   }
 
   it("should revert when contribution limit is higher than hardCap", async function () {
-    const { asOwner, end, rewards, start, owner, claimManagerMocked, defaultRoleVersion } = await loadFixture(async (wallets: Wallet[], provider: MockProvider) => {
-      const { timestamp } = await provider.getBlock("latest");
-      const start = timestamp + 15;
-      const initializePool = false
-      
-      return fixture(hardCap, start, wallets, provider, initializePool);
-    });
-    const  wrongContributionLimit = hardCap.add(1);
+    const { asOwner, end, rewards, start, owner, claimManagerMocked, defaultRoleVersion } = await loadFixture(
+      async (wallets: Wallet[], provider: MockProvider) => {
+        const { timestamp } = await provider.getBlock("latest");
+        const start = timestamp + 15;
+        const initializePool = false;
+
+        return fixture(hardCap, start, wallets, provider, initializePool);
+      },
+    );
+    const wrongContributionLimit = hardCap.add(1);
 
     await claimManagerMocked.mock.hasRole.withArgs(owner.address, ownerRoleDef, defaultRoleVersion).returns(true);
 
-    await expect(asOwner.init(start, end, ratioInt, hardCap, wrongContributionLimit , [patronRoleDef], {
-      value: rewards,
-    })).to.be.revertedWith("hardCap exceeded");
+    await expect(
+      asOwner.init(start, end, ratioInt, hardCap, wrongContributionLimit, [patronRoleDef], {
+        value: rewards,
+      }),
+    ).to.be.revertedWith("hardCap exceeded");
   });
 
   it("should revert when init rewards are lower than max future rewards", async function () {
@@ -165,27 +169,6 @@ describe("Staking Pool", function () {
     await expect(
       asOwner.init(start, end, ratioInt, hardCap, contributionLimit, [patronRoleDef], { value: smallerRewards }),
     ).to.be.revertedWith("Rewards lower than expected");
-  });
-
-  it("Ownership can't be transferred to current owner", async function () {
-    const { owner, asOwner } = await loadFixture(defaultFixture);
-
-    await expect(asOwner.changeOwner(owner.address)).to.be.revertedWith("changeOwner: already owner");
-  });
-
-  it("Ownership can't be transferred by non owner", async function () {
-    const { asPatron1, patron1, claimManagerMocked, defaultRoleVersion } = await loadFixture(defaultFixture);
-
-    await claimManagerMocked.mock.hasRole.withArgs(patron1.address, ownerRoleDef, defaultRoleVersion).returns(false);
-
-    await expect(asPatron1.changeOwner(patron1.address)).to.be.revertedWith("OnlyOwner: Not an owner");
-  });
-
-  it("Ownership is correctly transferred", async function () {
-    const { asOwner, patron1, stakingPool } = await loadFixture(defaultFixture);
-
-    const tx = await asOwner.changeOwner(patron1.address);
-    await expect(tx).to.emit(stakingPool, "OwnershipTransferred");
   });
 
   describe("Staking", async () => {
@@ -254,16 +237,18 @@ describe("Staking Pool", function () {
 
     it("should revert when staking pool reached the hard cap", async function () {
       const hardCap = contributionLimit;
-      const { asPatron1, asPatron2, asOwner, end, rewards, start } = await loadFixture(async (wallets: Wallet[], provider: MockProvider) => {
-        const { timestamp } = await provider.getBlock("latest");
-        const start = timestamp + 11;
-        
-        return fixture(hardCap, start, wallets, provider);
-      });
+      const { asPatron1, asPatron2, asOwner, end, rewards, start } = await loadFixture(
+        async (wallets: Wallet[], provider: MockProvider) => {
+          const { timestamp } = await provider.getBlock("latest");
+          const start = timestamp + 11;
 
-      await asOwner.init(start, end, ratioInt, hardCap, contributionLimit , [patronRoleDef], {
-          value: rewards,
-        });
+          return fixture(hardCap, start, wallets, provider);
+        },
+      );
+
+      await asOwner.init(start, end, ratioInt, hardCap, contributionLimit, [patronRoleDef], {
+        value: rewards,
+      });
       await asPatron1.stake({
         value: contributionLimit,
       });

--- a/test/StakingPool.test.ts
+++ b/test/StakingPool.test.ts
@@ -49,6 +49,7 @@ describe("Staking Pool", function () {
     [owner, patron1, patron2]: Wallet[],
     provider: MockProvider,
     initializePool = true,
+    travel = true,
   ) {
     const duration = 3600 * 24 * 30;
     const end = start + duration;
@@ -84,7 +85,10 @@ describe("Staking Pool", function () {
         await expect(tx).to.emit(stakingPool, "StakingPoolInitialized").withArgs(rewards, timestamp);
 
         // travel to staking event start
-        await timeTravel(provider, 10);
+        if (travel) {
+          const travelTo = start - timestamp;
+          await timeTravel(provider, travelTo);
+        }
       } catch (error) {
         console.log("Initialization Error: ");
         console.log(error);
@@ -240,7 +244,7 @@ describe("Staking Pool", function () {
       const { asPatron1, asPatron2, asOwner, end, rewards, start } = await loadFixture(
         async (wallets: Wallet[], provider: MockProvider) => {
           const { timestamp } = await provider.getBlock("latest");
-          const start = timestamp + 11;
+          const start = timestamp + 10;
 
           return fixture(hardCap, start, wallets, provider);
         },
@@ -276,7 +280,7 @@ describe("Staking Pool", function () {
       const { asPatron1 } = await loadFixture(async (wallets: Wallet[], provider: MockProvider) => {
         const { timestamp } = await provider.getBlock("latest");
         const start = timestamp + 100; //future
-        return fixture(hardCap, start, wallets, provider);
+        return fixture(hardCap, start, wallets, provider, true, false);
       });
 
       await expect(


### PR DESCRIPTION
This PR removes `owner` tracking since it does not have any application in the staking pool, ownership is controlled via claim manager contract.