### PR TITLE
feat: terminate function

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Deployed --> Initialized --> Open --> Expired --> Swept
 
 Transitions
 ```
-Deployed - smart contract deployed to the network and ownership transferred to organization owner address 
+Deployed - smart contract deployed to the network or terminate() called when in Initialized state
 
 Initialized - init() function executed
 

--- a/contracts/StakingPool.sol
+++ b/contracts/StakingPool.sol
@@ -19,6 +19,7 @@ contract StakingPool {
 	uint256 public contributionLimit;
 
 	uint256 public totalStaked;
+
 	bytes32[] private patronRoles;
 	bytes32 private ownerRole;
 
@@ -111,6 +112,21 @@ contract StakingPool {
 		remainingRewards = msg.value;
 
 		emit StakingPoolInitialized(msg.value, block.timestamp);
+	}
+
+	function terminate() external initialized onlyOwner {
+		require(start >= block.timestamp, "Cannot terminate after start");
+
+		uint256 payout = remainingRewards;
+
+		delete start;
+		delete end;
+		delete hourlyRatio;
+		delete hardCap;
+		delete contributionLimit;
+		delete patronRoles;
+
+		payable(msg.sender).transfer(payout);
 	}
 
 	function stake()


### PR DESCRIPTION
This PR adds terminate function that allows revert the init() by returning funds and resetting staking pool params.