### PR TITLE
fix: handle role versioning:

### DIFF
--- a/contracts/StakingPool.sol
+++ b/contracts/StakingPool.sol
@@ -9,7 +9,7 @@ contract StakingPool {
 	using ABDKMath64x64 for int128;
 	using RolesLibrary for address;
 
-	address public claimManager;
+	address private immutable claimManager;
 
 	uint256 public start;
 	uint256 public end;

--- a/contracts/StakingPool.sol
+++ b/contracts/StakingPool.sol
@@ -19,7 +19,7 @@ contract StakingPool {
 	uint256 public contributionLimit;
 
 	uint256 public totalStaked;
-
+	uint256 public roleVersion;
 	bytes32[] private patronRoles;
 	bytes32 private ownerRole;
 
@@ -44,7 +44,7 @@ contract StakingPool {
 	modifier onlyOwner() {
 		// restrict to accounts enrolled as owner at energyweb
 		require(
-			msg.sender.isOwner(claimManager, ownerRole),
+			msg.sender.isOwner(claimManager, ownerRole, roleVersion),
 			"OnlyOwner: Not an owner"
 		);
 		_;
@@ -53,7 +53,7 @@ contract StakingPool {
 	modifier onlyPatrons(address _agent) {
 		// checking patron role with claimManager
 		require(
-			_agent.hasRole(claimManager, patronRoles),
+			_agent.hasRole(claimManager, patronRoles, roleVersion),
 			"StakingPool: Not a patron"
 		);
 		_;
@@ -75,6 +75,7 @@ contract StakingPool {
 	constructor(bytes32 _ownerRole, address _claimManager) {
 		ownerRole = _ownerRole;
 		claimManager = _claimManager;
+		roleVersion = 1;
 	}
 
 	function init(
@@ -112,6 +113,10 @@ contract StakingPool {
 		remainingRewards = msg.value;
 
 		emit StakingPoolInitialized(msg.value, block.timestamp);
+	}
+
+	function  setRoleVersion(uint256 _newVersion) onlyOwner external {
+		roleVersion = _newVersion;
 	}
 
 	function terminate() external initialized onlyOwner {

--- a/contracts/libs/Roles.sol
+++ b/contracts/libs/Roles.sol
@@ -9,23 +9,24 @@ library RolesLibrary {
     function hasRole(
         address _userAddress,
         address _claimManagerAddress,
-        bytes32[] memory _roles
+        bytes32[] memory _roles,
+        uint256 _roleVersion
     ) internal view returns (bool) {
         if (_roles.length == 0) {
             return true;
         }
         TrustedClaimManager claimManager = TrustedClaimManager(_claimManagerAddress); // Contract deployed and maintained by EnergyWeb Fondation
         for (uint i = 0; i < _roles.length; i++) {
-            if (claimManager.hasRole(_userAddress, _roles[i], 0)) {
+            if (claimManager.hasRole(_userAddress, _roles[i], _roleVersion)) {
                 return true;
             }
         }
         return false;
     }
 
-    function isOwner(address _user, address _claimManagerAddress, bytes32 _ownerRole) internal view returns (bool){
+    function isOwner(address _user, address _claimManagerAddress, bytes32 _ownerRole, uint256 _roleVersion) internal view returns (bool){
         TrustedClaimManager claimManager = TrustedClaimManager(_claimManagerAddress); // Contract deployed and maintained by EnergyWeb Fondation
 
-        return (claimManager.hasRole(_user, _ownerRole, 0));
+        return (claimManager.hasRole(_user, _ownerRole, _roleVersion));
     }
 }

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -15,7 +15,18 @@ const deployer_privateKey = process.env.DEPLOYER_PRIV_KEY || defaultAccounts[0].
  * @type import('hardhat/config').HardhatUserConfig
  */
 module.exports = {
-  solidity: "0.8.6",
+  solidity: {
+    version: "0.8.6",
+    settings: {
+      optimizer: {
+        enabled: true,
+        runs: 200,
+      },
+    },
+  },
+  mocha: {
+    timeout: 20000,
+  },
   defaultNetwork: "hardhat",
   networks: {
     hardhat: {

--- a/test/StakingPool.test.ts
+++ b/test/StakingPool.test.ts
@@ -183,6 +183,10 @@ describe("Staking Pool", function () {
   });
 
   describe("Staking", async () => {
+    this.beforeEach(async () => {
+      console.log("...");
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    })
     it("should revert if patron doesn't have appropriate role", async function () {
       const { patron1, asPatron1, claimManagerMocked } = await loadFixture(defaultFixture);
       const defaultRoleVersion = 1;
@@ -244,7 +248,6 @@ describe("Staking Pool", function () {
           value: oneEWT,
         }),
       ).to.changeEtherBalance(stakingPool, oneEWT);
-      await new Promise((resolve) => setTimeout(resolve, 2000));
     });
 
     it("should revert when staking pool reached the hard cap", async function () {
@@ -252,15 +255,14 @@ describe("Staking Pool", function () {
       const { asPatron1, asPatron2, asOwner, end, rewards, start, provider } = await loadFixture(
         async (wallets: Wallet[], provider: MockProvider) => {
           const { timestamp } = await provider.getBlock("latest");
-          const start = timestamp + 12;
+          const start = timestamp + 20;
 
           return fixture(hardCap, start, wallets, provider);
         },
       );
-      asOwner.init(start, end, ratioInt, hardCap, contributionLimit, [patronRoleDef], {
+      await asOwner.init(start, end, ratioInt, hardCap, contributionLimit, [patronRoleDef], {
         value: rewards,
       });
-      await new Promise((resolve) => setTimeout(resolve, 2000));
 
       await asPatron1.stake({
         value: contributionLimit,


### PR DESCRIPTION
This PR fixes wrong roleVersion, removes hardcoded role version on `Roles` lib and improves role versioning

#### updates

- [x] setting a roleVersion variable on contract creation
- [x] setting default roleVersion to 1 instead of 0
- [x] adding a roleVersion setter to update role versioning
- [x] updating test to handle roleVersioning