### PR TITLE
fix: updating role version from 0 to 1

### DIFF
--- a/contracts/libs/Roles.sol
+++ b/contracts/libs/Roles.sol
@@ -16,7 +16,7 @@ library RolesLibrary {
         }
         TrustedClaimManager claimManager = TrustedClaimManager(_claimManagerAddress); // Contract deployed and maintained by EnergyWeb Fondation
         for (uint i = 0; i < _roles.length; i++) {
-            if (claimManager.hasRole(_userAddress, _roles[i], 0)) {
+            if (claimManager.hasRole(_userAddress, _roles[i], 1)) {
                 return true;
             }
         }
@@ -26,6 +26,6 @@ library RolesLibrary {
     function isOwner(address _user, address _claimManagerAddress, bytes32 _ownerRole) internal view returns (bool){
         TrustedClaimManager claimManager = TrustedClaimManager(_claimManagerAddress); // Contract deployed and maintained by EnergyWeb Fondation
 
-        return (claimManager.hasRole(_user, _ownerRole, 0));
+        return (claimManager.hasRole(_user, _ownerRole, 1));
     }
 }

--- a/test/StakingPool.test.ts
+++ b/test/StakingPool.test.ts
@@ -32,7 +32,7 @@ describe("Staking Pool", function () {
     provider: MockProvider,
     claimManagerMocked: MockContract,
   ) {
-    const defaultRoleVersion = 0;
+    const defaultRoleVersion = 1;
     const patronRole = utils.formatBytes32String("patron");
     const { owner, patron1, patron2 } = await loadFixture(defaultFixture);
     await claimManagerMocked.mock.hasRole.withArgs(owner.address, patronRole, defaultRoleVersion).returns(true);
@@ -54,7 +54,7 @@ describe("Staking Pool", function () {
     const duration = 3600 * 24 * 30;
     const end = start + duration;
 
-    const defaultRoleVersion = 0;
+    const defaultRoleVersion = 1;
     const claimManagerMocked = await deployMockContract(patron1, claimManagerABI);
 
     const stakingPool = (await deployContract(owner, StakingPoolContract, [
@@ -186,7 +186,7 @@ describe("Staking Pool", function () {
   describe("Staking", async () => {
     it("should revert if patron doesn't have appropriate role", async function () {
       const { patron1, asPatron1, claimManagerMocked } = await loadFixture(defaultFixture);
-      const defaultRoleVersion = 0;
+      const defaultRoleVersion = 1;
 
       await claimManagerMocked.mock.hasRole.withArgs(patron1.address, patronRoleDef, defaultRoleVersion).returns(false);
 

--- a/test/StakingPool.test.ts
+++ b/test/StakingPool.test.ts
@@ -17,6 +17,7 @@ describe("Staking Pool", function () {
   const ratio = 0.0000225;
   const ratioInt = utils.parseUnits(ratio.toString(), 18); // ratio as 18 digit number
 
+  const defaultRoleVersion = 1;
   const patronRoleDef = utils.namehash("email.roles.verification.apps.energyweb.iam.ewc");
   const ownerRoleDef = utils.namehash("owner.roles.stakingpool.apps.energyweb.iam.ewc");
 
@@ -32,7 +33,6 @@ describe("Staking Pool", function () {
     provider: MockProvider,
     claimManagerMocked: MockContract,
   ) {
-    const defaultRoleVersion = 1;
     const patronRole = utils.formatBytes32String("patron");
     const { owner, patron1, patron2 } = await loadFixture(defaultFixture);
     await claimManagerMocked.mock.hasRole.withArgs(owner.address, patronRole, defaultRoleVersion).returns(true);
@@ -53,8 +53,6 @@ describe("Staking Pool", function () {
   ) {
     const duration = 3600 * 24 * 30;
     const end = start + duration;
-
-    const defaultRoleVersion = 1;
     const claimManagerMocked = await deployMockContract(patron1, claimManagerABI);
 
     const stakingPool = (await deployContract(owner, StakingPoolContract, [
@@ -187,11 +185,9 @@ describe("Staking Pool", function () {
     this.beforeEach(async () => {
       console.log("...");
       await new Promise((resolve) => setTimeout(resolve, 2000));
-    })
+    });
     it("should revert if patron doesn't have appropriate role", async function () {
       const { patron1, asPatron1, claimManagerMocked } = await loadFixture(defaultFixture);
-      const defaultRoleVersion = 1;
-
       await claimManagerMocked.mock.hasRole.withArgs(patron1.address, patronRoleDef, defaultRoleVersion).returns(false);
 
       await expect(asPatron1.stake({ value: oneEWT })).to.be.revertedWith("StakingPool: Not a patron");

--- a/test/StakingPool.test.ts
+++ b/test/StakingPool.test.ts
@@ -116,7 +116,7 @@ describe("Staking Pool", function () {
 
   async function defaultFixture(wallets: Wallet[], provider: MockProvider) {
     const { timestamp } = await provider.getBlock("latest");
-    const start = timestamp + 10;
+    const start = timestamp + 12;
 
     return fixture(hardCap, start, wallets, provider);
   }
@@ -184,6 +184,10 @@ describe("Staking Pool", function () {
   });
 
   describe("Staking", async () => {
+    this.beforeEach(async () => {
+      console.log("...");
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    })
     it("should revert if patron doesn't have appropriate role", async function () {
       const { patron1, asPatron1, claimManagerMocked } = await loadFixture(defaultFixture);
       const defaultRoleVersion = 1;


### PR DESCRIPTION
This PR fixes wrong roleVersion, setting role version to `1` instead of `0`.

#### updates

- [x] Updating `Roles` contract to set version to `1`.
- [x] setting default roleVersion to 1 instead of 0 in tests
