### PR TITLE
fix: remove ability for pool owners to reinit pool

### DIFF
--- a/contracts/StakingPool.sol
+++ b/contracts/StakingPool.sol
@@ -74,6 +74,11 @@ contract StakingPool {
 		_;
 	}
 
+	modifier preventReset() {
+		require(start == 0, "Staking Pool already initialized");
+		_;
+	}
+
 	constructor(bytes32 _ownerRole, address _claimManager) {
 		ownerRole = _ownerRole;
 		claimManager = _claimManager;
@@ -86,7 +91,7 @@ contract StakingPool {
 		uint256 _hardCap,
 		uint256 _contributionLimit,
 		bytes32[] memory _patronRoles
-	) external payable onlyOwner {
+	) external payable onlyOwner preventReset {
 		require(
 			_start >= block.timestamp,
 			"Start date should be at least current block timestamp"

--- a/test/StakingPool.test.ts
+++ b/test/StakingPool.test.ts
@@ -257,9 +257,6 @@ describe("Staking Pool", function () {
         },
       );
 
-      await asOwner.init(start, end, ratioInt, hardCap, contributionLimit, [patronRoleDef], {
-        value: rewards,
-      });
       await asPatron1.stake({
         value: contributionLimit,
       });
@@ -270,6 +267,15 @@ describe("Staking Pool", function () {
         }),
       ).to.be.revertedWith("Staking pool is full");
     });
+
+    it("Should revert if Owner tries to reinitialize already launched Staking Pool", async function() {
+      const { asOwner, start, end, rewards } = await loadFixture(defaultFixture);
+      await expect(
+        asOwner.init(start, end, ratioInt, hardCap, contributionLimit, [patronRoleDef], {
+        value: rewards,
+      })
+      ).to.be.revertedWith("Staking Pool already initialized");
+    })
 
     it("should revert when stake is greater than contribution limit", async function () {
       const { asPatron1 } = await loadFixture(defaultFixture);


### PR DESCRIPTION
This PR ensures that staking Pool cannot be reinitialized by owners.

- Adding a modifier to the `init` function
- adding a unit test to check reinitialization revert