### PR TITLE
fix(snapshot-calulator): fixing address extraction

### DIFF
--- a/scripts/snapshot-calculator.ts
+++ b/scripts/snapshot-calculator.ts
@@ -22,7 +22,8 @@ const parseEvents = async (stakeLogs: Log[], blockNumber: number) => {
         const ethAddressSize = 40;
         const remainingSize = currentLog.topics[1].length - ethAddressSize;
         const currentAddress = "0x" + currentLog.topics[1].substring(remainingSize);
-        stakers.add(utils.getAddress(currentAddress));
+        utils.getAddress(currentAddress);
+        stakers.add(currentAddress);
       }
     }),
   );

--- a/scripts/snapshot-calculator.ts
+++ b/scripts/snapshot-calculator.ts
@@ -18,8 +18,10 @@ const parseEvents = async (stakeLogs: Log[], blockNumber: number) => {
   await Promise.all(
     stakeLogs.map(async (currentLog) => {
       if (currentLog.blockNumber <= blockNumber) {
-        //Removing the padding zeros
-        const currentAddress = utils.hexStripZeros(currentLog.topics[1]);
+        //Extracting the address from the topics logs
+        const ethAddressSize = 40;
+        const remainingSize = currentLog.topics[1].length - ethAddressSize;
+        const currentAddress = "0x" + currentLog.topics[1].substring(remainingSize);
         stakers.add(currentAddress);
       }
     }),

--- a/scripts/snapshot-calculator.ts
+++ b/scripts/snapshot-calculator.ts
@@ -22,7 +22,7 @@ const parseEvents = async (stakeLogs: Log[], blockNumber: number) => {
         const ethAddressSize = 40;
         const remainingSize = currentLog.topics[1].length - ethAddressSize;
         const currentAddress = "0x" + currentLog.topics[1].substring(remainingSize);
-        stakers.add(currentAddress);
+        stakers.add(utils.getAddress(currentAddress));
       }
     }),
   );


### PR DESCRIPTION
This PR solves address extraction to prevent wrong DID calculation when an address starts with `0x0...`.